### PR TITLE
Fixed stars shields not working and 2 URLs pointing to "rekit/nice-form-react"

### DIFF
--- a/packages/examples-antd/src/App.tsx
+++ b/packages/examples-antd/src/App.tsx
@@ -194,7 +194,7 @@ function App() {
         <div className="social">
           <a href="https://github.com/ebay/nice-form-react">
             <img
-              src="https://img.shields.io/github/stars/rekit/nice-form-react?style=social"
+              src="https://img.shields.io/github/stars/ebay/nice-form-react?style=social"
               alt="Github Repo"
             />
           </a>

--- a/packages/examples-formik/src/App.tsx
+++ b/packages/examples-formik/src/App.tsx
@@ -188,16 +188,16 @@ function App() {
         <div className="social">
           <a href="https://github.com/ebay/nice-form-react">
             <img
-              src="https://img.shields.io/github/stars/rekit/nice-form-react?style=social"
+              src="https://img.shields.io/github/stars/ebay/nice-form-react?style=social"
               alt="Github Repo"
             />
           </a>
           <br />
-          <a href="https://github.com/rekit/nice-form-react">
+          <a href="https://github.com/ebay/nice-form-react">
             <img src="https://img.shields.io/badge/API-Reference-green" alt="api reference" />
           </a>
           <br />
-          <a href="https://codesandbox.io/s/github/rekit/nice-form-react/tree/master/examples-v4">
+          <a href="https://codesandbox.io/s/github/ebay/nice-form-react/tree/master/examples-v4">
             <img
               width="150px"
               src="https://codesandbox.io/static/img/play-codesandbox.svg"


### PR DESCRIPTION
This should fix the stars shields not working at the bottom left of the documentation pages:
![image](https://github.com/eBay/nice-form-react/assets/2467392/6b4a6052-9291-4687-b373-06e0e8e3df8c)
And also fixes two URLs pointing to rekit/nice-form-react. 🙂