### PR TITLE
Examples cleanup

### DIFF
--- a/packages/examples-antd/src/examples/Basic.tsx
+++ b/packages/examples-antd/src/examples/Basic.tsx
@@ -81,9 +81,6 @@ const Basic = () => {
       { key: 'date-picker', label: 'Date Picker', widget: 'date-picker', fullWidth: true },
     ],
   };
-  // if (NiceForm.getFieldValue('checkbox', meta, form)) {
-  //   meta.fields.splice(2, 1);
-  // }
   const handleFinish = (values: any) => {
     form.validateFields().then(() => {
       console.log('on finish: ', values);

--- a/packages/examples-antd/src/examples/ComplexLayout.tsx
+++ b/packages/examples-antd/src/examples/ComplexLayout.tsx
@@ -19,7 +19,7 @@ export default () => {
         render() {
           return (
             <fieldset>
-              <legend>Contact Infomation</legend>
+              <legend>Contact Information</legend>
             </fieldset>
           );
         },

--- a/packages/examples-antd/src/examples/ComplexLayout.tsx
+++ b/packages/examples-antd/src/examples/ComplexLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { Form, Button } from 'antd';
 import NiceForm from '@ebay/nice-form-react';
 import type { AntdNiceFormMeta } from '@ebay/nice-form-react/lib/esm/adapters/antdAdapter';

--- a/packages/examples-antd/src/examples/Coordinated.tsx
+++ b/packages/examples-antd/src/examples/Coordinated.tsx
@@ -1,4 +1,4 @@
-import { useCallback, ChangeEvent } from 'react';
+import { useCallback } from 'react';
 import { Form, Button } from 'antd';
 import type { RadioChangeEvent } from 'antd';
 import NiceForm from '@ebay/nice-form-react';

--- a/packages/examples-antd/src/examples/DynamicFields.tsx
+++ b/packages/examples-antd/src/examples/DynamicFields.tsx
@@ -1,7 +1,5 @@
-import React, { useCallback } from 'react';
 import { Form, Button } from 'antd';
 import NiceForm from '@ebay/nice-form-react';
-
 import type { AntdNiceFormMeta } from '@ebay/nice-form-react/lib/esm/adapters/antdAdapter';
 
 export default () => {

--- a/packages/examples-antd/src/examples/FieldCondition.tsx
+++ b/packages/examples-antd/src/examples/FieldCondition.tsx
@@ -1,7 +1,5 @@
-import React, { useCallback } from 'react';
 import { Form, Button } from 'antd';
 import NiceForm from '@ebay/nice-form-react';
-
 import type { AntdNiceFormMeta } from '@ebay/nice-form-react/lib/esm/adapters/antdAdapter';
 
 export default () => {

--- a/packages/examples-antd/src/examples/FormList.tsx
+++ b/packages/examples-antd/src/examples/FormList.tsx
@@ -1,6 +1,5 @@
 import { useCallback } from 'react';
-import { Form, Button, Input } from 'antd';
-import { MinusCircleOutlined } from '@ant-design/icons';
+import { Form, Button } from 'antd';
 import NiceForm from '@ebay/nice-form-react';
 
 export default () => {

--- a/packages/examples-antd/src/examples/FormListManual.tsx
+++ b/packages/examples-antd/src/examples/FormListManual.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { Form, Button, Input } from 'antd';
+import { Form, Button } from 'antd';
 import { MinusCircleOutlined } from '@ant-design/icons';
 import NiceForm from '@ebay/nice-form-react';
 

--- a/packages/examples-antd/src/examples/Mixed.tsx
+++ b/packages/examples-antd/src/examples/Mixed.tsx
@@ -1,7 +1,6 @@
 import { useCallback } from 'react';
-import { Form, Select, Input, Button } from 'antd';
+import { Form, Input, Button } from 'antd';
 import NiceForm from '@ebay/nice-form-react';
-const { Option } = Select;
 
 export default () => {
   const [form] = Form.useForm();

--- a/packages/examples-antd/src/examples/MultipleSections.tsx
+++ b/packages/examples-antd/src/examples/MultipleSections.tsx
@@ -56,7 +56,7 @@ export default () => {
         <NiceForm meta={meta2} />
       </fieldset>
       <fieldset>
-        <legend>Contact Infomation</legend>
+        <legend>Contact Information</legend>
         <NiceForm meta={meta3} />
       </fieldset>
       <Form.Item className="form-footer" wrapperCol={{ span: 16, offset: 8 }}>

--- a/packages/examples-antd/src/examples/ViewEdit.tsx
+++ b/packages/examples-antd/src/examples/ViewEdit.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { Form, Button, Modal, message } from 'antd';
+import { useCallback, useState } from 'react';
+import { Form, Button, message } from 'antd';
 import NiceForm from '@ebay/nice-form-react';
-import dayjs, { Dayjs } from 'dayjs';
+import dayjs from 'dayjs';
 import type { AntdNiceFormMeta } from '@ebay/nice-form-react/lib/esm/adapters/antdAdapter';
 
 const MOCK_INFO = {
@@ -13,7 +13,7 @@ const MOCK_INFO = {
   city: 'Shanghai',
   address: 'No.1000 Some Road, Zhangjiang Park, Pudong New District',
 };
-const DateView = ({ value }: { value: Dayjs }) => value.format('MMM Do YYYY');
+
 export default () => {
   const [form] = Form.useForm();
   const [viewMode, setViewMode] = useState(true);

--- a/packages/examples-antd/src/examples/ViewEdit.tsx
+++ b/packages/examples-antd/src/examples/ViewEdit.tsx
@@ -25,7 +25,7 @@ export default () => {
       setPending(false);
       setPersonalInfo(values);
       setViewMode(true);
-      message.success('Infomation updated.');
+      message.success('Information updated.');
     }, 1500);
   }, []);
 
@@ -57,7 +57,7 @@ export default () => {
     <div>
       <Form layout="horizontal" form={form} onFinish={handleFinish} style={{ width: '600px' }}>
         <h1 style={{ height: '40px', fontSize: '16px', marginTop: '50px', color: '#888' }}>
-          Personal Infomation
+          Personal Information
           {viewMode && (
             <Button type="link" onClick={() => setViewMode(false)} style={{ float: 'right' }}>
               Edit

--- a/packages/examples-antd/src/examples/ViewMode.tsx
+++ b/packages/examples-antd/src/examples/ViewMode.tsx
@@ -39,7 +39,7 @@ const ViewMode = () => {
   return (
     <div>
       <div style={{ width: '800px' }}>
-        <h1>Personal Infomation</h1>
+        <h1>Personal Information</h1>
         <NiceForm meta={meta} />
       </div>
     </div>

--- a/packages/examples-antd/src/examples/ViewMode.tsx
+++ b/packages/examples-antd/src/examples/ViewMode.tsx
@@ -1,6 +1,5 @@
 import dayjs from 'dayjs';
 import type { Dayjs } from 'dayjs';
-import { Form } from 'antd';
 import NiceForm from '@ebay/nice-form-react';
 
 const DateView = ({ value }: { value: Dayjs }) => value.format('MMM Do YYYY');

--- a/packages/examples-antd/src/examples/Wizard.tsx
+++ b/packages/examples-antd/src/examples/Wizard.tsx
@@ -87,8 +87,6 @@ export default () => {
 
   // Clone the meta for dynamic change
   const newWizardMeta = JSON.parse(JSON.stringify(wizardMeta));
-  // In a wizard, every field should be preserved when swtich steps.
-  // newWizardMeta.steps.forEach(s => s.formMeta.fields.forEach(f => (f.preserve = true)))
   if (form.getFieldValue('noAccountInfo')) {
     newWizardMeta.steps.splice(1, 1);
   }

--- a/packages/examples-formik/src/examples/Basic.tsx
+++ b/packages/examples-formik/src/examples/Basic.tsx
@@ -46,7 +46,6 @@ const Basic = () => {
     select: 'Apple',
   };
   const getMeta = (form: FormikProps<typeof initialValues>) => {
-    // console.log(form.errors);
     const formMeta: FormikMuiNiceFormMeta = {
       columns: 1,
       form,

--- a/packages/examples-formik/src/examples/MultipleSections.tsx
+++ b/packages/examples-formik/src/examples/MultipleSections.tsx
@@ -73,7 +73,7 @@ const MultipleSections = () => {
           </section>
           <section style={{ marginBottom: 20 }}>
             <header style={{ marginBottom: 16 }}>
-              Contact Infomation
+              Contact Information
               <Divider />
             </header>
             <NiceForm meta={meta3} />

--- a/packages/examples-formik/src/examples/ViewEdit.tsx
+++ b/packages/examples-formik/src/examples/ViewEdit.tsx
@@ -4,7 +4,6 @@ import dayjs from 'dayjs';
 import { FormikMuiNiceFormMeta } from '@ebay/nice-form-react/adapters/formikMuiAdapter';
 import { Form, Formik, FormikProps } from 'formik';
 import { Button } from '@mui/material';
-// import type { AntdNiceFormMeta } from '@ebay/nice-form-react/lib/esm/adapters/antdAdapter';
 
 const MOCK_INFO = {
   name: { first: 'Nate', last: 'Wang' },
@@ -50,12 +49,6 @@ const ViewEdit = () => {
         },
         { key: 'name.last', label: 'Last Name', fullWidth: true, widget: 'text', required: true },
         { key: 'gender', label: 'Gender', widget: 'radio-group', options: ['Male', 'Female'] },
-        // {
-        //   key: 'dateOfBirth',
-        //   label: 'Date of Birth',
-        //   widget: 'date-picker',
-        //   // viewWidget: DateView,
-        // },
         { key: 'email', label: 'Email' },
         { key: 'phone', label: 'Phone' },
         { key: 'address', label: 'Address', colSpan: 2, clear: 'left' },

--- a/packages/examples-formik/src/examples/ViewEdit.tsx
+++ b/packages/examples-formik/src/examples/ViewEdit.tsx
@@ -84,7 +84,7 @@ const ViewEdit = () => {
   return (
     <div>
       <h1 style={{ fontSize: '16px', marginTop: '50px', color: '#888' }}>
-        Personal Infomation
+        Personal Information
         {viewMode && (
           <Button
             onClick={() => setViewMode(!viewMode)}

--- a/packages/examples-formik/src/examples/ViewMode.tsx
+++ b/packages/examples-formik/src/examples/ViewMode.tsx
@@ -50,7 +50,7 @@ const ViewMode = () => {
 
   return (
     <div style={{ width: '800px' }}>
-      <h1>Personal Infomation</h1>
+      <h1>Personal Information</h1>
       <NiceForm meta={meta} />
     </div>
   );

--- a/packages/examples-formik/src/examples/ViewMode.tsx
+++ b/packages/examples-formik/src/examples/ViewMode.tsx
@@ -19,7 +19,7 @@ const ViewMode = () => {
     email: 'myemail@gmail.com',
     gender: 'Male',
     dateOfBirth: dayjs('2100-01-01'),
-    // phone: '15988888888',
+    phone: '15988888888',
     city: 'Shanghai',
     address:
       'No.1000 Some Road, Zhangjiang Park, Pudong New District,Zhangjiang Park, Pudong New DistrictZhangjiang Park, Pudong New District',

--- a/packages/examples-formik/src/examples/Wizard.tsx
+++ b/packages/examples-formik/src/examples/Wizard.tsx
@@ -105,11 +105,6 @@ const Wizard = () => {
   // Clone the meta for dynamic change
   const newWizardMeta = JSON.parse(JSON.stringify(wizardMeta));
 
-  // In a wizard, every field should be preserved when swtich steps.
-  // newWizardMeta.steps.forEach(s => s.formMeta.fields.forEach(f => (f.preserve = true)))
-  // if (values.noAccountInfo) {
-  //   newWizardMeta.steps.splice(1, 1);
-  // }
   // Generate a general review step
   const reviewFields: object[] = [];
   newWizardMeta.steps.forEach((s: StepItem, i: number) => {


### PR DESCRIPTION
- Removes commented out code from the examples.
- Removes unused imports and variables from examples.
- Makes the ViewMode example consistent between Formik and Antd (Formik was missing the "phone" field)
- Fixes some typos in the examples