### PR TITLE
Made the examples self contained

### DIFF
--- a/packages/examples-antd/src/App.tsx
+++ b/packages/examples-antd/src/App.tsx
@@ -3,8 +3,8 @@ import './App.css';
 import CodeViewer from './CodeViewer';
 import useHash from './useHash';
 
-const lazyImportComponent = (filename: string) => {
-  return lazy(() => import(`./examples/${filename}`));
+const lazyComponent = (importFunction: () => Promise<{ default: React.ComponentType }>) => { 
+  return lazy(importFunction);
 };
 
 const examples: {
@@ -16,80 +16,80 @@ const examples: {
 } = {
   simple: {
     name: 'Simple',
-    component: lazyImportComponent('Simple'),
+    component: lazyComponent(() => import('./examples/Simple')),
     description: 'The most simple usage.',
   },
   basic: {
     name: 'Basic',
-    component: lazyImportComponent('Basic'),
+    component: lazyComponent(() => import('./examples/Basic')),
     description: 'Basic usage.'
   },
   'view-mode': {
     name: 'View Mode',
-    component: lazyImportComponent('ViewMode'),
+    component: lazyComponent(() => import('./examples/ViewMode')),
     description:
       'FormBuilder could also be used as view mode just for displaying information in form layout. It could be used even without Form.',
   },
   'view-edit': {
     name: 'View / Edit',
-    component: lazyImportComponent('ViewEdit'),
+    component: lazyComponent(() => import('./examples/ViewEdit')),
     description: 'FormBuilder makes it super easy to toggle view/edit mode of a form.',
   },
   'dynamic-fields': {
     name: 'Dynamic Fields',
-    component: lazyImportComponent('DynamicFields'),
+    component: lazyComponent(() => import('./examples/DynamicFields')),
     description:
       "You can dynamically add or remove fields according to the user's input. In this example, if choose other, then a new input appears.",
   },
   'field-condition': {
     name: 'Field Condition',
-    component: lazyImportComponent('FieldCondition'),
+    component: lazyComponent(() => import('./examples/FieldCondition')),
     description:
       'By condition property, you can control whether to render a field or not. In this example, if choose other, then a new input appears.',
   },
   'form-list': {
     name: 'Form List',
-    component: lazyImportComponent('FormList'),
+    component: lazyComponent(() => import('./examples/FormList')),
     description: 'Antd form list support.',
   },
   'form-list-manual': {
     name: 'Manual Form List',
-    component: lazyImportComponent('FormListManual'),
+    component: lazyComponent(() => import('./examples/FormListManual')),
     description: 'Antd form list support.',
   },
 
   'async-data-source': {
     name: 'Async Data Source',
-    component: lazyImportComponent('AsyncDataSource'),
+    component: lazyComponent(() => import('./examples/AsyncDataSource')),
     description:
       'Some form field widgets may need to load data source if necessary, the sample shows how to do it',
   },
   'multiple-columns': {
     name: 'Multiple Columns',
-    component: lazyImportComponent('MultipleColumns'),
+    component: lazyComponent(() => import('./examples/MultipleColumns')),
     description:
       "It's easy to set multiple columns layout for the form. Note it should be able to divide 24",
   },
   'complex-layout': {
     name: 'Complex Layout',
-    component: lazyImportComponent('ComplexLayout'),
+    component: lazyComponent(() => import('./examples/ComplexLayout')),
     description: 'The example shows a complex layout. Similar approach with multiple columns.',
   },
   'multiple-sections': {
     name: 'Multiple Sections',
-    component: lazyImportComponent('MultipleSections'),
+    component: lazyComponent(() => import('./examples/MultipleSections')),
     description:
       'Some times you need to group fields into different fieldset, or need more complex layout. You can use multiple form metas in one form.',
   },
   'single-field': {
     name: 'Single Field',
-    component: lazyImportComponent('SingleField'),
+    component: lazyComponent(() => import('./examples/SingleField')),
     description:
       'You can use FormBuilder for even a single form field. This example also shows inline layout of the form.',
   },
   validation: {
     name: 'Validation',
-    component: lazyImportComponent('Validation'),
+    component: lazyComponent(() => import('./examples/Validation')),
     description: (
       <span>
         You can use rules property to specify how to validate fields. For more information please go
@@ -106,31 +106,31 @@ const examples: {
   },
   'form-in-modal': {
     name: 'Form in Modal',
-    component: lazyImportComponent('FormInModal'),
+    component: lazyComponent(() => import('./examples/FormInModal')),
     description:
       'The example shows how to use form in a dialog to call api and show status in dialog buttons.',
   },
   coordinated: {
     name: 'Coordinated Controls',
-    component: lazyImportComponent('Coordinated'),
+    component: lazyComponent(() => import('./examples/Coordinated')),
     description:
       'You can set field value according to input of another control by use form.setFieldsValue api.',
   },
   'custom-component': {
     name: 'Custom Component',
-    component: lazyImportComponent('CustomComponent'),
+    component: lazyComponent(() => import('./examples/CustomComponent')),
     description:
       "It's easy to create your own form field component, ether to get new capabilities or even just for layout.",
   },
   mixed: {
     name: 'Mixed',
-    component: lazyImportComponent('Mixed'),
+    component: lazyComponent(() => import('./examples/Mixed')),
     description:
       'Form builder is designed to not limit original antd form api, so you can use them together.',
   },
   wizard: {
     name: 'Wizard',
-    component: lazyImportComponent('Wizard'),
+    component: lazyComponent(() => import('./examples/Wizard')),
     description:
       'Wizard is an advanced usage of form builder, you can design your own meta structure to support dynamic wizard.',
   },

--- a/packages/examples-antd/src/App.tsx
+++ b/packages/examples-antd/src/App.tsx
@@ -1,107 +1,95 @@
-import React, { useState } from 'react';
-import useHash from './useHash';
+import React, { Suspense, lazy } from 'react';
 import './App.css';
-import NiceFormMeta from '@ebay/nice-form-react/src/NiceFormMeta';
 import CodeViewer from './CodeViewer';
-import Basic from './examples/Basic';
-import Simple from './examples/Simple';
-import ViewEdit from './examples/ViewEdit';
-import ComplexLayout from './examples/ComplexLayout';
-import DynamicFields from './examples/DynamicFields';
-import FieldCondition from './examples/FieldCondition';
-import ViewMode from './examples/ViewMode';
-import AsyncDataSource from './examples/AsyncDataSource';
-import MultipleColumns from './examples/MultipleColumns';
-import MultipleSections from './examples/MultipleSections';
-import SingleField from './examples/SingleField';
-import Validation from './examples/Validation';
-import FormInModal from './examples/FormInModal';
-import Coordinated from './examples/Coordinated';
-import CustomComponent from './examples/CustomComponent';
-import Mixed from './examples/Mixed';
-import Wizard from './examples/Wizard';
-import FormList from './examples/FormList';
-import FormListManual from './examples/FormListManual';
+import useHash from './useHash';
+
+const lazyImportComponent = (filename: string) => {
+  return lazy(() => import(`./examples/${filename}`));
+};
 
 const examples: {
   [key: string]: {
     name: string;
-    component: () => JSX.Element;
+    component: React.LazyExoticComponent<React.ComponentType>;
     description: React.ReactNode;
   };
 } = {
   simple: {
     name: 'Simple',
-    component: Simple,
+    component: lazyImportComponent('Simple'),
     description: 'The most simple usage.',
   },
-  basic: { name: 'Basic', component: Basic, description: 'Basic usage.' },
+  basic: {
+    name: 'Basic',
+    component: lazyImportComponent('Basic'),
+    description: 'Basic usage.'
+  },
   'view-mode': {
     name: 'View Mode',
-    component: ViewMode,
+    component: lazyImportComponent('ViewMode'),
     description:
       'FormBuilder could also be used as view mode just for displaying information in form layout. It could be used even without Form.',
   },
   'view-edit': {
     name: 'View / Edit',
-    component: ViewEdit,
+    component: lazyImportComponent('ViewEdit'),
     description: 'FormBuilder makes it super easy to toggle view/edit mode of a form.',
   },
   'dynamic-fields': {
     name: 'Dynamic Fields',
-    component: DynamicFields,
+    component: lazyImportComponent('DynamicFields'),
     description:
       "You can dynamically add or remove fields according to the user's input. In this example, if choose other, then a new input appears.",
   },
   'field-condition': {
     name: 'Field Condition',
-    component: FieldCondition,
+    component: lazyImportComponent('FieldCondition'),
     description:
       'By condition property, you can control whether to render a field or not. In this example, if choose other, then a new input appears.',
   },
   'form-list': {
     name: 'Form List',
-    component: FormList,
+    component: lazyImportComponent('FormList'),
     description: 'Antd form list support.',
   },
   'form-list-manual': {
     name: 'Manual Form List',
-    component: FormListManual,
+    component: lazyImportComponent('FormListManual'),
     description: 'Antd form list support.',
   },
 
   'async-data-source': {
     name: 'Async Data Source',
-    component: AsyncDataSource,
+    component: lazyImportComponent('AsyncDataSource'),
     description:
       'Some form field widgets may need to load data source if necessary, the sample shows how to do it',
   },
   'multiple-columns': {
     name: 'Multiple Columns',
-    component: MultipleColumns,
+    component: lazyImportComponent('MultipleColumns'),
     description:
       "It's easy to set multiple columns layout for the form. Note it should be able to divide 24",
   },
   'complex-layout': {
     name: 'Complex Layout',
-    component: ComplexLayout,
+    component: lazyImportComponent('ComplexLayout'),
     description: 'The example shows a complex layout. Similar approach with multiple columns.',
   },
   'multiple-sections': {
     name: 'Multiple Sections',
-    component: MultipleSections,
+    component: lazyImportComponent('MultipleSections'),
     description:
       'Some times you need to group fields into different fieldset, or need more complex layout. You can use multiple form metas in one form.',
   },
   'single-field': {
     name: 'Single Field',
-    component: SingleField,
+    component: lazyImportComponent('SingleField'),
     description:
       'You can use FormBuilder for even a single form field. This example also shows inline layout of the form.',
   },
   validation: {
     name: 'Validation',
-    component: Validation,
+    component: lazyImportComponent('Validation'),
     description: (
       <span>
         You can use rules property to specify how to validate fields. For more information please go
@@ -118,31 +106,31 @@ const examples: {
   },
   'form-in-modal': {
     name: 'Form in Modal',
-    component: FormInModal,
+    component: lazyImportComponent('FormInModal'),
     description:
       'The example shows how to use form in a dialog to call api and show status in dialog buttons.',
   },
   coordinated: {
     name: 'Coordinated Controls',
-    component: Coordinated,
+    component: lazyImportComponent('Coordinated'),
     description:
       'You can set field value according to input of another control by use form.setFieldsValue api.',
   },
   'custom-component': {
     name: 'Custom Component',
-    component: CustomComponent,
+    component: lazyImportComponent('CustomComponent'),
     description:
       "It's easy to create your own form field component, ether to get new capabilities or even just for layout.",
   },
   mixed: {
     name: 'Mixed',
-    component: Mixed,
+    component: lazyImportComponent('Mixed'),
     description:
       'Form builder is designed to not limit original antd form api, so you can use them together.',
   },
   wizard: {
     name: 'Wizard',
-    component: Wizard,
+    component: lazyImportComponent('Wizard'),
     description:
       'Wizard is an advanced usage of form builder, you can design your own meta structure to support dynamic wizard.',
   },
@@ -213,10 +201,12 @@ function App() {
         </div>
       </div>
       <div className="example-container">
-        <div>{renderExample()}</div>
-        <div className="code-container">
-          <CodeViewer code={current} />
-        </div>
+        <Suspense>
+          <div>{renderExample()}</div>
+          <div className="code-container">
+            <CodeViewer code={current} />
+          </div>
+        </Suspense>
       </div>
     </div>
   );

--- a/packages/examples-antd/src/examples/AsyncDataSource.tsx
+++ b/packages/examples-antd/src/examples/AsyncDataSource.tsx
@@ -1,7 +1,10 @@
-import { useCallback, useState, useEffect } from 'react';
-import { Form, Button } from 'antd';
-import NiceForm from '@ebay/nice-form-react';
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import antdAdapter from '@ebay/nice-form-react/adapters/antdAdapter';
 import type { AntdNiceFormMeta } from '@ebay/nice-form-react/lib/esm/adapters/antdAdapter';
+import { Button, Form } from 'antd';
+import { useCallback, useEffect, useState } from 'react';
+
+niceFormConfig.addAdapter(antdAdapter);
 
 const MOCK_DATA: {
   [key: string]: string[];

--- a/packages/examples-antd/src/examples/Basic.tsx
+++ b/packages/examples-antd/src/examples/Basic.tsx
@@ -1,6 +1,9 @@
-import { Form, Button, Rate } from 'antd';
-import NiceForm from '@ebay/nice-form-react';
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import antdAdapter from '@ebay/nice-form-react/adapters/antdAdapter';
 import type { AntdNiceFormMeta } from '@ebay/nice-form-react/lib/esm/adapters/antdAdapter';
+import { Button, Form, Rate } from 'antd';
+
+niceFormConfig.addAdapter(antdAdapter);
 
 const Basic = () => {
   const [form] = Form.useForm();

--- a/packages/examples-antd/src/examples/ComplexLayout.tsx
+++ b/packages/examples-antd/src/examples/ComplexLayout.tsx
@@ -1,7 +1,10 @@
-import { useCallback } from 'react';
-import { Form, Button } from 'antd';
-import NiceForm from '@ebay/nice-form-react';
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import antdAdapter from '@ebay/nice-form-react/adapters/antdAdapter';
 import type { AntdNiceFormMeta } from '@ebay/nice-form-react/lib/esm/adapters/antdAdapter';
+import { Button, Form } from 'antd';
+import { useCallback } from 'react';
+
+niceFormConfig.addAdapter(antdAdapter);
 
 export default () => {
   const [form] = Form.useForm();

--- a/packages/examples-antd/src/examples/Coordinated.tsx
+++ b/packages/examples-antd/src/examples/Coordinated.tsx
@@ -1,8 +1,11 @@
-import { useCallback } from 'react';
-import { Form, Button } from 'antd';
-import type { RadioChangeEvent } from 'antd';
-import NiceForm from '@ebay/nice-form-react';
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import antdAdapter from '@ebay/nice-form-react/adapters/antdAdapter';
 import type { AntdNiceFormMeta } from '@ebay/nice-form-react/lib/esm/adapters/antdAdapter';
+import type { RadioChangeEvent } from 'antd';
+import { Button, Form } from 'antd';
+import { useCallback } from 'react';
+
+niceFormConfig.addAdapter(antdAdapter);
 
 export default () => {
   const [form] = Form.useForm();

--- a/packages/examples-antd/src/examples/CustomComponent.tsx
+++ b/packages/examples-antd/src/examples/CustomComponent.tsx
@@ -1,7 +1,10 @@
-import { useCallback } from 'react';
-import { Form, Button, Input, Select, InputNumber, Row, Col } from 'antd';
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import antdAdapter from '@ebay/nice-form-react/adapters/antdAdapter';
 import type { InputProps } from 'antd';
-import NiceForm from '@ebay/nice-form-react';
+import { Button, Col, Form, Input, InputNumber, Row, Select } from 'antd';
+import { useCallback } from 'react';
+
+niceFormConfig.addAdapter(antdAdapter);
 
 const Option = Select.Option;
 // Here define a custom component just for layout

--- a/packages/examples-antd/src/examples/DynamicFields.tsx
+++ b/packages/examples-antd/src/examples/DynamicFields.tsx
@@ -1,6 +1,9 @@
-import { Form, Button } from 'antd';
-import NiceForm from '@ebay/nice-form-react';
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import antdAdapter from '@ebay/nice-form-react/adapters/antdAdapter';
 import type { AntdNiceFormMeta } from '@ebay/nice-form-react/lib/esm/adapters/antdAdapter';
+import { Button, Form } from 'antd';
+
+niceFormConfig.addAdapter(antdAdapter);
 
 export default () => {
   const [form] = Form.useForm();

--- a/packages/examples-antd/src/examples/FieldCondition.tsx
+++ b/packages/examples-antd/src/examples/FieldCondition.tsx
@@ -1,6 +1,9 @@
-import { Form, Button } from 'antd';
-import NiceForm from '@ebay/nice-form-react';
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import antdAdapter from '@ebay/nice-form-react/adapters/antdAdapter';
 import type { AntdNiceFormMeta } from '@ebay/nice-form-react/lib/esm/adapters/antdAdapter';
+import { Button, Form } from 'antd';
+
+niceFormConfig.addAdapter(antdAdapter);
 
 export default () => {
   const [form] = Form.useForm();

--- a/packages/examples-antd/src/examples/FormInModal.tsx
+++ b/packages/examples-antd/src/examples/FormInModal.tsx
@@ -1,6 +1,9 @@
-import { useState, useCallback } from 'react';
-import { Form, Button, Modal } from 'antd';
-import NiceForm from '@ebay/nice-form-react';
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import antdAdapter from '@ebay/nice-form-react/adapters/antdAdapter';
+import { Button, Form, Modal } from 'antd';
+import { useCallback, useState } from 'react';
+
+niceFormConfig.addAdapter(antdAdapter);
 
 export default () => {
   const [form] = Form.useForm();

--- a/packages/examples-antd/src/examples/FormList.tsx
+++ b/packages/examples-antd/src/examples/FormList.tsx
@@ -1,6 +1,9 @@
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import antdAdapter from '@ebay/nice-form-react/adapters/antdAdapter';
+import { Button, Form } from 'antd';
 import { useCallback } from 'react';
-import { Form, Button } from 'antd';
-import NiceForm from '@ebay/nice-form-react';
+
+niceFormConfig.addAdapter(antdAdapter);
 
 export default () => {
   const meta = {

--- a/packages/examples-antd/src/examples/FormListManual.tsx
+++ b/packages/examples-antd/src/examples/FormListManual.tsx
@@ -1,7 +1,10 @@
-import { useCallback } from 'react';
-import { Form, Button } from 'antd';
 import { MinusCircleOutlined } from '@ant-design/icons';
-import NiceForm from '@ebay/nice-form-react';
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import antdAdapter from '@ebay/nice-form-react/adapters/antdAdapter';
+import { Button, Form } from 'antd';
+import { useCallback } from 'react';
+
+niceFormConfig.addAdapter(antdAdapter);
 
 export default () => {
   const meta = {

--- a/packages/examples-antd/src/examples/Mixed.tsx
+++ b/packages/examples-antd/src/examples/Mixed.tsx
@@ -1,6 +1,9 @@
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import antdAdapter from '@ebay/nice-form-react/adapters/antdAdapter';
+import { Button, Form, Input } from 'antd';
 import { useCallback } from 'react';
-import { Form, Input, Button } from 'antd';
-import NiceForm from '@ebay/nice-form-react';
+
+niceFormConfig.addAdapter(antdAdapter);
 
 export default () => {
   const [form] = Form.useForm();

--- a/packages/examples-antd/src/examples/MultipleColumns.tsx
+++ b/packages/examples-antd/src/examples/MultipleColumns.tsx
@@ -1,8 +1,11 @@
-import { useState, useCallback } from 'react';
-import { Form, Button } from 'antd';
-import type { RadioChangeEvent } from 'antd';
-import NiceForm from '@ebay/nice-form-react';
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import antdAdapter from '@ebay/nice-form-react/adapters/antdAdapter';
 import type { AntdNiceFormMeta } from '@ebay/nice-form-react/lib/esm/adapters/antdAdapter';
+import type { RadioChangeEvent } from 'antd';
+import { Button, Form } from 'antd';
+import { useCallback, useState } from 'react';
+
+niceFormConfig.addAdapter(antdAdapter);
 
 export default () => {
   const [form] = Form.useForm();

--- a/packages/examples-antd/src/examples/MultipleSections.tsx
+++ b/packages/examples-antd/src/examples/MultipleSections.tsx
@@ -1,7 +1,10 @@
-import { useCallback } from 'react';
-import { Form, Button } from 'antd';
-import NiceForm from '@ebay/nice-form-react';
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import antdAdapter from '@ebay/nice-form-react/adapters/antdAdapter';
 import type { AntdNiceFormMeta } from '@ebay/nice-form-react/lib/esm/adapters/antdAdapter';
+import { Button, Form } from 'antd';
+import { useCallback } from 'react';
+
+niceFormConfig.addAdapter(antdAdapter);
 
 export default () => {
   const [form] = Form.useForm();

--- a/packages/examples-antd/src/examples/Simple.tsx
+++ b/packages/examples-antd/src/examples/Simple.tsx
@@ -1,6 +1,9 @@
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import antdAdapter from '@ebay/nice-form-react/adapters/antdAdapter';
+import { Button, Form } from 'antd';
 import { useCallback } from 'react';
-import { Form, Button } from 'antd';
-import NiceForm from '@ebay/nice-form-react';
+
+niceFormConfig.addAdapter(antdAdapter);
 
 export default () => {
   const meta = {

--- a/packages/examples-antd/src/examples/SingleField.tsx
+++ b/packages/examples-antd/src/examples/SingleField.tsx
@@ -1,6 +1,9 @@
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import antdAdapter from '@ebay/nice-form-react/adapters/antdAdapter';
+import { Button, Form } from 'antd';
 import { useCallback } from 'react';
-import { Form, Button } from 'antd';
-import NiceForm from '@ebay/nice-form-react';
+
+niceFormConfig.addAdapter(antdAdapter);
 
 export default () => {
   const handleFinish = useCallback((values: any) => {

--- a/packages/examples-antd/src/examples/Validation.tsx
+++ b/packages/examples-antd/src/examples/Validation.tsx
@@ -1,7 +1,10 @@
-import { useCallback } from 'react';
-import { Form, Button } from 'antd';
-import NiceForm from '@ebay/nice-form-react';
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import antdAdapter from '@ebay/nice-form-react/adapters/antdAdapter';
 import type { AntdNiceFormMeta } from '@ebay/nice-form-react/lib/esm/adapters/antdAdapter';
+import { Button, Form } from 'antd';
+import { useCallback } from 'react';
+
+niceFormConfig.addAdapter(antdAdapter);
 
 const MOCK_USERNAMES: {
   [key: string]: boolean;

--- a/packages/examples-antd/src/examples/ViewEdit.tsx
+++ b/packages/examples-antd/src/examples/ViewEdit.tsx
@@ -1,8 +1,11 @@
-import { useCallback, useState } from 'react';
-import { Form, Button, message } from 'antd';
-import NiceForm from '@ebay/nice-form-react';
-import dayjs from 'dayjs';
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import antdAdapter from '@ebay/nice-form-react/adapters/antdAdapter';
 import type { AntdNiceFormMeta } from '@ebay/nice-form-react/lib/esm/adapters/antdAdapter';
+import { Button, Form, message } from 'antd';
+import dayjs from 'dayjs';
+import { useCallback, useState } from 'react';
+
+niceFormConfig.addAdapter(antdAdapter);
 
 const MOCK_INFO = {
   name: { first: 'Nate', last: 'Wang' },

--- a/packages/examples-antd/src/examples/ViewMode.tsx
+++ b/packages/examples-antd/src/examples/ViewMode.tsx
@@ -1,6 +1,9 @@
-import dayjs from 'dayjs';
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import antdAdapter from '@ebay/nice-form-react/adapters/antdAdapter';
 import type { Dayjs } from 'dayjs';
-import NiceForm from '@ebay/nice-form-react';
+import dayjs from 'dayjs';
+
+niceFormConfig.addAdapter(antdAdapter);
 
 const DateView = ({ value }: { value: Dayjs }) => value.format('MMM Do YYYY');
 

--- a/packages/examples-antd/src/examples/Wizard.tsx
+++ b/packages/examples-antd/src/examples/Wizard.tsx
@@ -1,8 +1,11 @@
-import { useCallback, useState } from 'react';
-import { Form, Button, Steps } from 'antd';
-import NiceForm from '@ebay/nice-form-react';
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import antdAdapter from '@ebay/nice-form-react/adapters/antdAdapter';
 import { NiceFormFieldType } from '@ebay/nice-form-react/lib/esm/NiceFormMeta';
+import { Button, Form, Steps } from 'antd';
 import type { Dayjs } from 'dayjs';
+import { useCallback, useState } from 'react';
+
+niceFormConfig.addAdapter(antdAdapter);
 
 const { Step } = Steps;
 const DateView = ({ value }: { value: Dayjs }) => (value ? value.format('MMM Do YYYY') : 'N/A');

--- a/packages/examples-antd/src/main.tsx
+++ b/packages/examples-antd/src/main.tsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-// import niceFormConfig from '@ebay/nice-form-react/config';
-import { config as niceFormConfig } from '@ebay/nice-form-react';
-import antdAdapter from '@ebay/nice-form-react/adapters/antdAdapter';
 import App from './App';
 import './index.css';
-
-niceFormConfig.addAdapter(antdAdapter);
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/packages/examples-formik/src/App.tsx
+++ b/packages/examples-formik/src/App.tsx
@@ -3,8 +3,8 @@ import './App.css';
 import CodeViewer from './CodeViewer';
 import useHash from './useHash';
 
-const lazyImportComponent = (filename: string) => {
-  return lazy(() => import(`./examples/${filename}`));
+const lazyComponent = (importFunction: () => Promise<{ default: React.ComponentType }>) => { 
+  return lazy(importFunction);
 };
 
 const examples: {
@@ -16,64 +16,64 @@ const examples: {
 } = {
   simple: {
     name: 'Simple',
-    component: lazyImportComponent('Simple'),
+    component: lazyComponent(() => import('./examples/Simple')),
     description: 'The most simple usage.',
   },
   basic: {
     name: 'Basic',
-    component: lazyImportComponent('Basic'),
+    component: lazyComponent(() => import('./examples/Basic')),
     description: 'Basic usage.'
   },
   'view-mode': {
     name: 'View Mode',
-    component: lazyImportComponent('ViewMode'),
+    component: lazyComponent(() => import('./examples/ViewMode')),
     description:
       'FormBuilder could also be used as view mode just for displaying information in form layout. It could be used even without Form.',
   },
   'view-edit': {
     name: 'View / Edit',
-    component: lazyImportComponent('ViewEdit'),
+    component: lazyComponent(() => import('./examples/ViewEdit')),
     description: 'FormBuilder makes it super easy to toggle view/edit mode of a form.',
   },
   'dynamic-fields': {
     name: 'Dynamic Fields',
-    component: lazyImportComponent('DynamicFields'),
+    component: lazyComponent(() => import('./examples/DynamicFields')),
     description:
       "You can dynamically add or remove fields according to the user's input. In this example, if choose other, then a new input appears.",
   },
   'field-condition': {
     name: 'Field Condition',
-    component: lazyImportComponent('FieldCondition'),
+    component: lazyComponent(() => import('./examples/FieldCondition')),
     description:
       'By condition property, you can control whether to render a field or not. In this example, if choose other, then a new input appears.',
   },
   'form-list': {
     name: 'Form List',
-    component: lazyImportComponent('FormList'),
+    component: lazyComponent(() => import('./examples/FormList')),
     description:
       'Form list is a common usage of form builder, it allows you to add/remove form fields dynamically.',
   },
 
   'async-data-source': {
     name: 'Async Data Source',
-    component: lazyImportComponent('AsyncDataSource'),
+    component: lazyComponent(() => import('./examples/AsyncDataSource')),
     description:
       'Some form field widgets may need to load data source if necessary, the sample shows how to do it',
   },
   'multiple-columns': {
     name: 'Multiple Columns',
-    component: lazyImportComponent('MultipleColumns'),
+    component: lazyComponent(() => import('./examples/MultipleColumns')),
     description:
       "It's easy to set multiple columns layout for the form. Note it should be able to divide 24",
   },
   'complex-layout': {
     name: 'Complex Layout',
-    component: lazyImportComponent('ComplexLayout'),
+    component: lazyComponent(() => import('./examples/ComplexLayout')),
     description: 'The example shows a complex layout. Similar approach with multiple columns.',
   },
   'multiple-sections': {
     name: 'Multiple Sections',
-    component: lazyImportComponent('MultipleSections'),
+    component: lazyComponent(() => import('./examples/MultipleSections')),
     description:
       'Some times you need to group fields into different fieldset, or need more complex layout. You can use multiple form builders in one form.',
   },
@@ -85,7 +85,7 @@ const examples: {
   // },
   validation: {
     name: 'Validation',
-    component: lazyImportComponent('Validation'),
+    component: lazyComponent(() => import('./examples/Validation')),
     description: (
       <span>
         You can use rules property to specify how to validate fields. For more information please go
@@ -102,31 +102,31 @@ const examples: {
   },
   'form-in-modal': {
     name: 'Form in Modal',
-    component: lazyImportComponent('FormInModal'),
+    component: lazyComponent(() => import('./examples/FormInModal')),
     description:
       'The example shows how to use form in a dialog to call api and show status in dialog buttons.',
   },
   coordinated: {
     name: 'Coordinated Controls',
-    component: lazyImportComponent('Coordinated'),
+    component: lazyComponent(() => import('./examples/Coordinated')),
     description:
       'You can set field value according to input of another control by use form.setFieldsValue api.',
   },
   'custom-component': {
     name: 'Custom Component',
-    component: lazyImportComponent('CustomComponent'),
+    component: lazyComponent(() => import('./examples/CustomComponent')),
     description:
       "It's easy to create your own form field component, ether to get new capabilities or even just for layout.",
   },
   mixed: {
     name: 'Mixed',
-    component: lazyImportComponent('Mixed'),
+    component: lazyComponent(() => import('./examples/Mixed')),
     description:
       'Form builder is designed to not limit original antd form api, so you can use them together.',
   },
   wizard: {
     name: 'Wizard',
-    component: lazyImportComponent('Wizard'),
+    component: lazyComponent(() => import('./examples/Wizard')),
     description:
       'Wizard is an advanced usage of form builder, you can design your own meta structure to support dynamic wizard.',
   },

--- a/packages/examples-formik/src/App.tsx
+++ b/packages/examples-formik/src/App.tsx
@@ -1,89 +1,79 @@
-import React from 'react';
-import useHash from './useHash';
+import React, { Suspense, lazy } from 'react';
 import './App.css';
-// import NiceFormMeta from '@ebay/nice-form-react/src/NiceFormMeta';
 import CodeViewer from './CodeViewer';
-import Basic from './examples/Basic';
-import Simple from './examples/Simple';
-import ViewEdit from './examples/ViewEdit';
-import ComplexLayout from './examples/ComplexLayout';
-import DynamicFields from './examples/DynamicFields';
-import FieldCondition from './examples/FieldCondition';
-import ViewMode from './examples/ViewMode';
-import AsyncDataSource from './examples/AsyncDataSource';
-import MultipleColumns from './examples/MultipleColumns';
-import MultipleSections from './examples/MultipleSections';
-import Validation from './examples/Validation';
-import FormInModal from './examples/FormInModal';
-import Coordinated from './examples/Coordinated';
-import CustomComponent from './examples/CustomComponent';
-import FormList from './examples/FormList';
-import Mixed from './examples/Mixed';
-import Wizard from './examples/Wizard';
+import useHash from './useHash';
+
+const lazyImportComponent = (filename: string) => {
+  return lazy(() => import(`./examples/${filename}`));
+};
 
 const examples: {
   [key: string]: {
     name: string;
-    component?: () => JSX.Element;
+    component?: React.LazyExoticComponent<React.ComponentType>;
     description: React.ReactNode;
   };
 } = {
   simple: {
     name: 'Simple',
-    component: Simple,
+    component: lazyImportComponent('Simple'),
     description: 'The most simple usage.',
   },
-  basic: { name: 'Basic', component: Basic, description: 'Basic usage.' },
+  basic: {
+    name: 'Basic',
+    component: lazyImportComponent('Basic'),
+    description: 'Basic usage.'
+  },
   'view-mode': {
     name: 'View Mode',
-    component: ViewMode,
+    component: lazyImportComponent('ViewMode'),
     description:
       'FormBuilder could also be used as view mode just for displaying information in form layout. It could be used even without Form.',
   },
   'view-edit': {
     name: 'View / Edit',
-    component: ViewEdit,
+    component: lazyImportComponent('ViewEdit'),
     description: 'FormBuilder makes it super easy to toggle view/edit mode of a form.',
   },
   'dynamic-fields': {
     name: 'Dynamic Fields',
-    component: DynamicFields,
+    component: lazyImportComponent('DynamicFields'),
     description:
       "You can dynamically add or remove fields according to the user's input. In this example, if choose other, then a new input appears.",
   },
   'field-condition': {
     name: 'Field Condition',
-    component: FieldCondition,
+    component: lazyImportComponent('FieldCondition'),
     description:
       'By condition property, you can control whether to render a field or not. In this example, if choose other, then a new input appears.',
   },
   'form-list': {
     name: 'Form List',
-    component: FormList,
+    component: lazyImportComponent('FormList'),
     description:
       'Form list is a common usage of form builder, it allows you to add/remove form fields dynamically.',
   },
 
   'async-data-source': {
     name: 'Async Data Source',
-    component: AsyncDataSource,
+    component: lazyImportComponent('AsyncDataSource'),
     description:
       'Some form field widgets may need to load data source if necessary, the sample shows how to do it',
   },
   'multiple-columns': {
     name: 'Multiple Columns',
-    component: MultipleColumns,
+    component: lazyImportComponent('MultipleColumns'),
     description:
       "It's easy to set multiple columns layout for the form. Note it should be able to divide 24",
   },
   'complex-layout': {
     name: 'Complex Layout',
-    component: ComplexLayout,
+    component: lazyImportComponent('ComplexLayout'),
     description: 'The example shows a complex layout. Similar approach with multiple columns.',
   },
   'multiple-sections': {
     name: 'Multiple Sections',
-    component: MultipleSections,
+    component: lazyImportComponent('MultipleSections'),
     description:
       'Some times you need to group fields into different fieldset, or need more complex layout. You can use multiple form builders in one form.',
   },
@@ -95,7 +85,7 @@ const examples: {
   // },
   validation: {
     name: 'Validation',
-    component: Validation,
+    component: lazyImportComponent('Validation'),
     description: (
       <span>
         You can use rules property to specify how to validate fields. For more information please go
@@ -112,31 +102,31 @@ const examples: {
   },
   'form-in-modal': {
     name: 'Form in Modal',
-    component: FormInModal,
+    component: lazyImportComponent('FormInModal'),
     description:
       'The example shows how to use form in a dialog to call api and show status in dialog buttons.',
   },
   coordinated: {
     name: 'Coordinated Controls',
-    component: Coordinated,
+    component: lazyImportComponent('Coordinated'),
     description:
       'You can set field value according to input of another control by use form.setFieldsValue api.',
   },
   'custom-component': {
     name: 'Custom Component',
-    component: CustomComponent,
+    component: lazyImportComponent('CustomComponent'),
     description:
       "It's easy to create your own form field component, ether to get new capabilities or even just for layout.",
   },
   mixed: {
     name: 'Mixed',
-    component: Mixed,
+    component: lazyImportComponent('Mixed'),
     description:
       'Form builder is designed to not limit original antd form api, so you can use them together.',
   },
   wizard: {
     name: 'Wizard',
-    component: Wizard,
+    component: lazyImportComponent('Wizard'),
     description:
       'Wizard is an advanced usage of form builder, you can design your own meta structure to support dynamic wizard.',
   },
@@ -207,10 +197,12 @@ function App() {
         </div>
       </div>
       <div className="example-container">
-        <div>{renderExample()}</div>
-        <div className="code-container">
-          <CodeViewer code={current} />
-        </div>
+        <Suspense>
+          <div>{renderExample()}</div>
+          <div className="code-container">
+            <CodeViewer code={current} />
+          </div>
+        </Suspense>
       </div>
     </div>
   );

--- a/packages/examples-formik/src/examples/AsyncDataSource.tsx
+++ b/packages/examples-formik/src/examples/AsyncDataSource.tsx
@@ -1,8 +1,13 @@
-import { useState, useEffect } from 'react';
-import { Form, Formik, useFormikContext } from 'formik';
-import Button from '@mui/material/Button';
-import NiceForm from '@ebay/nice-form-react';
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import formikAdapter from '@ebay/nice-form-react/adapters/formikAdapter';
+import formikMuiAdapter from '@ebay/nice-form-react/adapters/formikMuiAdapter';
 import type { NiceFormMeta } from '@ebay/nice-form-react/types';
+import Button from '@mui/material/Button';
+import { Form, Formik, useFormikContext } from 'formik';
+import { useEffect, useState } from 'react';
+
+niceFormConfig.addAdapter(formikAdapter);
+niceFormConfig.addAdapter(formikMuiAdapter);
 
 const MOCK_DATA: {
   [key: string]: string[];

--- a/packages/examples-formik/src/examples/Basic.tsx
+++ b/packages/examples-formik/src/examples/Basic.tsx
@@ -1,13 +1,17 @@
-import { Formik, Form, FormikProps } from 'formik';
-import NiceForm from '@ebay/nice-form-react';
-import { FormikMuiNiceFormMeta } from '@ebay/nice-form-react/adapters/formikMuiAdapter';
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import formikAdapter from '@ebay/nice-form-react/adapters/formikAdapter';
+import formikMuiAdapter, { FormikMuiNiceFormMeta } from '@ebay/nice-form-react/adapters/formikMuiAdapter';
 import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
-import { fieldToDateTimePicker } from 'formik-mui-x-date-pickers';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import type { Dayjs } from 'dayjs';
+import { Form, Formik, FormikProps } from 'formik';
+import { fieldToDateTimePicker } from 'formik-mui-x-date-pickers';
+
+niceFormConfig.addAdapter(formikAdapter);
+niceFormConfig.addAdapter(formikMuiAdapter);
 
 const options = ['Apple', 'Orange', 'Banana'];
 

--- a/packages/examples-formik/src/examples/ComplexLayout.tsx
+++ b/packages/examples-formik/src/examples/ComplexLayout.tsx
@@ -1,7 +1,13 @@
-import { Formik, Form } from 'formik';
+import { config as niceFormConfig } from '@ebay/nice-form-react';
 import NiceForm from '@ebay/nice-form-react/NiceForm';
+import formikAdapter from '@ebay/nice-form-react/adapters/formikAdapter';
+import formikMuiAdapter from '@ebay/nice-form-react/adapters/formikMuiAdapter';
 import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
+import { Form, Formik } from 'formik';
+
+niceFormConfig.addAdapter(formikAdapter);
+niceFormConfig.addAdapter(formikMuiAdapter);
 
 const ComplexLayout = () => {
   const meta = {

--- a/packages/examples-formik/src/examples/Coordinated.tsx
+++ b/packages/examples-formik/src/examples/Coordinated.tsx
@@ -1,7 +1,12 @@
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import formikAdapter from '@ebay/nice-form-react/adapters/formikAdapter';
+import formikMuiAdapter from '@ebay/nice-form-react/adapters/formikMuiAdapter';
 import Button from '@mui/material/Button';
-import NiceForm from '@ebay/nice-form-react';
-import { Formik, Form } from 'formik';
 import type { FormikHelpers } from 'formik';
+import { Form, Formik } from 'formik';
+
+niceFormConfig.addAdapter(formikAdapter);
+niceFormConfig.addAdapter(formikMuiAdapter);
 
 interface FormValues {
   gender?: string;

--- a/packages/examples-formik/src/examples/CustomComponent.tsx
+++ b/packages/examples-formik/src/examples/CustomComponent.tsx
@@ -1,13 +1,38 @@
-import Grid from '@mui/material/Grid';
-import { Formik, Form } from 'formik';
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import formikAdapter from '@ebay/nice-form-react/adapters/formikAdapter';
+import formikMuiAdapter from '@ebay/nice-form-react/adapters/formikMuiAdapter';
 import Button from '@mui/material/Button';
-import NiceForm from '@ebay/nice-form-react';
+import Grid from '@mui/material/Grid';
 import MenuItem from '@mui/material/MenuItem';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import TextField from '@mui/material/TextField';
-import { FieldInputProps, FormikProps, FieldMetaProps } from 'formik';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import type { Dayjs } from 'dayjs';
+import { FieldInputProps, FieldMetaProps, Form, Formik, FormikProps } from 'formik';
+import { fieldToDatePicker } from 'formik-mui-x-date-pickers';
+
+niceFormConfig.addAdapter(formikAdapter);
+niceFormConfig.addAdapter(formikMuiAdapter);
+
+const MyDatePicker = ({ ...props }) => {
+  props.onChange = (value: Dayjs | null) => {
+    props.form.setFieldTouched(props.field.name, true, false);
+    props.form.setFieldValue(props.field.name, value, true);
+    props.field.onChange(value);
+  };
+  props.onBlur = () => {
+    props.form.setFieldTouched(props.field.name, true, true);
+    props.field.onBlur();
+  };
+  return (
+    <DatePicker {...fieldToDatePicker({ field: props.field, form: props.form, meta: props.meta })}>
+      {props.children}
+    </DatePicker>
+  );
+};
+
+NiceForm.defineWidget('date-picker', MyDatePicker, ({ field }) => field);
 
 interface FormValues {
   product: string;

--- a/packages/examples-formik/src/examples/DynamicFields.tsx
+++ b/packages/examples-formik/src/examples/DynamicFields.tsx
@@ -1,7 +1,12 @@
+import { config as niceFormConfig } from '@ebay/nice-form-react';
 import NiceForm from '@ebay/nice-form-react/NiceForm';
-import { FormikMuiNiceFormMeta } from '@ebay/nice-form-react/adapters/formikMuiAdapter';
-import { Formik, Form, FormikProps } from 'formik';
+import formikAdapter from '@ebay/nice-form-react/adapters/formikAdapter';
+import formikMuiAdapter, { FormikMuiNiceFormMeta } from '@ebay/nice-form-react/adapters/formikMuiAdapter';
 import Button from '@mui/material/Button';
+import { Form, Formik, FormikProps } from 'formik';
+
+niceFormConfig.addAdapter(formikAdapter);
+niceFormConfig.addAdapter(formikMuiAdapter);
 
 interface FormValues {
   favoriteFruit: string;

--- a/packages/examples-formik/src/examples/FieldCondition.tsx
+++ b/packages/examples-formik/src/examples/FieldCondition.tsx
@@ -1,6 +1,12 @@
+import { config as niceFormConfig } from '@ebay/nice-form-react';
 import NiceForm from '@ebay/nice-form-react/NiceForm';
-import { Formik, Form, FormikProps } from 'formik';
+import formikAdapter from '@ebay/nice-form-react/adapters/formikAdapter';
+import formikMuiAdapter from '@ebay/nice-form-react/adapters/formikMuiAdapter';
 import Button from '@mui/material/Button';
+import { Form, Formik, FormikProps } from 'formik';
+
+niceFormConfig.addAdapter(formikAdapter);
+niceFormConfig.addAdapter(formikMuiAdapter);
 
 interface FormValues {
   favoriteFruit: string;

--- a/packages/examples-formik/src/examples/FormInModal.tsx
+++ b/packages/examples-formik/src/examples/FormInModal.tsx
@@ -1,12 +1,17 @@
-import { useCallback, useState } from 'react';
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import formikAdapter from '@ebay/nice-form-react/adapters/formikAdapter';
+import formikMuiAdapter from '@ebay/nice-form-react/adapters/formikMuiAdapter';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
-import NiceForm from '@ebay/nice-form-react';
-import { Formik, Form } from 'formik';
+import { Form, Formik } from 'formik';
 import { SnackbarProvider, enqueueSnackbar } from 'notistack';
+import { useCallback, useState } from 'react';
+
+niceFormConfig.addAdapter(formikAdapter);
+niceFormConfig.addAdapter(formikMuiAdapter);
 
 export default function FormInModal() {
   const [open, setOpen] = useState(false);

--- a/packages/examples-formik/src/examples/FormList.tsx
+++ b/packages/examples-formik/src/examples/FormList.tsx
@@ -1,6 +1,11 @@
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import formikAdapter from '@ebay/nice-form-react/adapters/formikAdapter';
+import formikMuiAdapter from '@ebay/nice-form-react/adapters/formikMuiAdapter';
 import Button from '@mui/material/Button';
-import NiceForm from '@ebay/nice-form-react';
-import { Formik, Form } from 'formik';
+import { Form, Formik } from 'formik';
+
+niceFormConfig.addAdapter(formikAdapter);
+niceFormConfig.addAdapter(formikMuiAdapter);
 
 const FormList = () => {
   const meta = {

--- a/packages/examples-formik/src/examples/Mixed.tsx
+++ b/packages/examples-formik/src/examples/Mixed.tsx
@@ -1,12 +1,17 @@
-import { Form, Formik } from 'formik';
-import NiceForm from '@ebay/nice-form-react';
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import formikAdapter from '@ebay/nice-form-react/adapters/formikAdapter';
+import formikMuiAdapter from '@ebay/nice-form-react/adapters/formikMuiAdapter';
 import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import { fieldToDatePicker } from 'formik-mui-x-date-pickers';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import type { Dayjs } from 'dayjs';
+import { Form, Formik } from 'formik';
+import { fieldToDatePicker } from 'formik-mui-x-date-pickers';
+
+niceFormConfig.addAdapter(formikAdapter);
+niceFormConfig.addAdapter(formikMuiAdapter);
 
 const MyDatePicker = ({ ...props }) => {
   props.onChange = (value: Dayjs | null) => {

--- a/packages/examples-formik/src/examples/MultipleColumns.tsx
+++ b/packages/examples-formik/src/examples/MultipleColumns.tsx
@@ -1,10 +1,36 @@
-import { useState } from 'react';
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import formikAdapter from '@ebay/nice-form-react/adapters/formikAdapter';
+import formikMuiAdapter from '@ebay/nice-form-react/adapters/formikMuiAdapter';
 import Button from '@mui/material/Button';
-import NiceForm from '@ebay/nice-form-react';
-import { Formik, Form, FormikProps } from 'formik';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import type { Dayjs } from 'dayjs';
+import { Form, Formik, FormikProps } from 'formik';
+import { fieldToDatePicker } from 'formik-mui-x-date-pickers';
+import { useState } from 'react';
+
+niceFormConfig.addAdapter(formikAdapter);
+niceFormConfig.addAdapter(formikMuiAdapter);
+
+const MyDatePicker = ({ ...props }) => {
+  props.onChange = (value: Dayjs | null) => {
+    props.form.setFieldTouched(props.field.name, true, false);
+    props.form.setFieldValue(props.field.name, value, true);
+    props.field.onChange(value);
+  };
+  props.onBlur = () => {
+    props.form.setFieldTouched(props.field.name, true, true);
+    props.field.onBlur();
+  };
+  return (
+    <DatePicker {...fieldToDatePicker({ field: props.field, form: props.form, meta: props.meta })}>
+      {props.children}
+    </DatePicker>
+  );
+};
+
+NiceForm.defineWidget('date-picker', MyDatePicker, ({ field }) => field);
 
 interface FormValues {
   columns: number;

--- a/packages/examples-formik/src/examples/MultipleSections.tsx
+++ b/packages/examples-formik/src/examples/MultipleSections.tsx
@@ -1,9 +1,37 @@
-import { Formik, Form } from 'formik';
+import { config as niceFormConfig } from '@ebay/nice-form-react';
 import NiceForm from '@ebay/nice-form-react/NiceForm';
+import formikAdapter from '@ebay/nice-form-react/adapters/formikAdapter';
+import formikMuiAdapter from '@ebay/nice-form-react/adapters/formikMuiAdapter';
 import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import type { Dayjs } from 'dayjs';
+import { Form, Formik } from 'formik';
+import { fieldToDatePicker } from 'formik-mui-x-date-pickers';
+
+niceFormConfig.addAdapter(formikAdapter);
+niceFormConfig.addAdapter(formikMuiAdapter);
+
+const MyDatePicker = ({ ...props }) => {
+  props.onChange = (value: Dayjs | null) => {
+    props.form.setFieldTouched(props.field.name, true, false);
+    props.form.setFieldValue(props.field.name, value, true);
+    props.field.onChange(value);
+  };
+  props.onBlur = () => {
+    props.form.setFieldTouched(props.field.name, true, true);
+    props.field.onBlur();
+  };
+  return (
+    <DatePicker {...fieldToDatePicker({ field: props.field, form: props.form, meta: props.meta })}>
+      {props.children}
+    </DatePicker>
+  );
+};
+
+NiceForm.defineWidget('date-picker', MyDatePicker, ({ field }) => field);
 
 const MultipleSections = () => {
   const meta = {

--- a/packages/examples-formik/src/examples/Simple.tsx
+++ b/packages/examples-formik/src/examples/Simple.tsx
@@ -1,7 +1,11 @@
-import { Form, Formik, FormikProps } from 'formik';
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import formikAdapter from '@ebay/nice-form-react/adapters/formikAdapter';
+import formikMuiAdapter, { FormikMuiNiceFormMeta } from '@ebay/nice-form-react/adapters/formikMuiAdapter';
 import Button from '@mui/material/Button';
-import NiceForm from '@ebay/nice-form-react';
-import { FormikMuiNiceFormMeta } from '@ebay/nice-form-react/adapters/formikMuiAdapter';
+import { Form, Formik, FormikProps } from 'formik';
+
+niceFormConfig.addAdapter(formikAdapter);
+niceFormConfig.addAdapter(formikMuiAdapter);
 
 const Simple = () => {
   const initialValues = {

--- a/packages/examples-formik/src/examples/Validation.tsx
+++ b/packages/examples-formik/src/examples/Validation.tsx
@@ -1,6 +1,11 @@
-import NiceForm from '@ebay/nice-form-react';
-import { Formik, Form, FormikProps } from 'formik';
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import formikAdapter from '@ebay/nice-form-react/adapters/formikAdapter';
+import formikMuiAdapter from '@ebay/nice-form-react/adapters/formikMuiAdapter';
 import Button from '@mui/material/Button';
+import { Form, Formik, FormikProps } from 'formik';
+
+niceFormConfig.addAdapter(formikAdapter);
+niceFormConfig.addAdapter(formikMuiAdapter);
 
 const MOCK_USERNAMES: {
   [key: string]: boolean;

--- a/packages/examples-formik/src/examples/ViewEdit.tsx
+++ b/packages/examples-formik/src/examples/ViewEdit.tsx
@@ -1,9 +1,13 @@
-import { useCallback, useState } from 'react';
-import NiceForm from '@ebay/nice-form-react';
-import dayjs from 'dayjs';
-import { FormikMuiNiceFormMeta } from '@ebay/nice-form-react/adapters/formikMuiAdapter';
-import { Form, Formik, FormikProps } from 'formik';
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import formikAdapter from '@ebay/nice-form-react/adapters/formikAdapter';
+import formikMuiAdapter, { FormikMuiNiceFormMeta } from '@ebay/nice-form-react/adapters/formikMuiAdapter';
 import { Button } from '@mui/material';
+import dayjs from 'dayjs';
+import { Form, Formik, FormikProps } from 'formik';
+import { useCallback, useState } from 'react';
+
+niceFormConfig.addAdapter(formikAdapter);
+niceFormConfig.addAdapter(formikMuiAdapter);
 
 const MOCK_INFO = {
   name: { first: 'Nate', last: 'Wang' },

--- a/packages/examples-formik/src/examples/ViewMode.tsx
+++ b/packages/examples-formik/src/examples/ViewMode.tsx
@@ -1,8 +1,13 @@
-import dayjs from 'dayjs';
-import type { Dayjs } from 'dayjs';
-import NiceForm, { NiceFormMeta } from '@ebay/nice-form-react';
+import NiceForm, { NiceFormMeta, config as niceFormConfig } from '@ebay/nice-form-react';
+import formikAdapter from '@ebay/nice-form-react/adapters/formikAdapter';
+import formikMuiAdapter from '@ebay/nice-form-react/adapters/formikMuiAdapter';
 import { InputLabel } from '@mui/material';
+import type { Dayjs } from 'dayjs';
+import dayjs from 'dayjs';
 import { ReactElement } from 'react';
+
+niceFormConfig.addAdapter(formikAdapter);
+niceFormConfig.addAdapter(formikMuiAdapter);
 
 const DateView = ({ value, label }: { value: Dayjs; label: ReactElement }) => {
   return (

--- a/packages/examples-formik/src/examples/Wizard.tsx
+++ b/packages/examples-formik/src/examples/Wizard.tsx
@@ -1,18 +1,44 @@
-import { useState } from 'react';
-import NiceForm from '@ebay/nice-form-react';
-import type { Dayjs } from 'dayjs';
-import { Formik, Form, FormikProps } from 'formik';
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
+import formikAdapter from '@ebay/nice-form-react/adapters/formikAdapter';
+import formikMuiAdapter, {
+  FormikMuiNiceFormField,
+  FormikMuiNiceFormMeta,
+} from '@ebay/nice-form-react/adapters/formikMuiAdapter';
 import Button from '@mui/material/Button';
-import Stepper from '@mui/material/Stepper';
+import Divider from '@mui/material/Divider';
 import Step from '@mui/material/Step';
 import StepLabel from '@mui/material/StepLabel';
-import Divider from '@mui/material/Divider';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import Stepper from '@mui/material/Stepper';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import {
-  FormikMuiNiceFormMeta,
-  FormikMuiNiceFormField,
-} from '@ebay/nice-form-react/adapters/formikMuiAdapter';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import type { Dayjs } from 'dayjs';
+import { Form, Formik, FormikProps } from 'formik';
+import { fieldToDatePicker } from 'formik-mui-x-date-pickers';
+import { useState } from 'react';
+
+niceFormConfig.addAdapter(formikAdapter);
+niceFormConfig.addAdapter(formikMuiAdapter);
+
+const MyDatePicker = ({ ...props }) => {
+  props.onChange = (value: Dayjs | null) => {
+    props.form.setFieldTouched(props.field.name, true, false);
+    props.form.setFieldValue(props.field.name, value, true);
+    props.field.onChange(value);
+  };
+  props.onBlur = () => {
+    props.form.setFieldTouched(props.field.name, true, true);
+    props.field.onBlur();
+  };
+  return (
+    <DatePicker {...fieldToDatePicker({ field: props.field, form: props.form, meta: props.meta })}>
+      {props.children}
+    </DatePicker>
+  );
+};
+
+NiceForm.defineWidget('date-picker', MyDatePicker, ({ field }) => field);
+
 const DateView = ({ value }: { value: Dayjs }) => (value ? value.format('MMM Do YYYY') : 'N/A');
 
 NiceForm.defineWidget('date-view', DateView, ({ field }) => field);

--- a/packages/examples-formik/src/main.tsx
+++ b/packages/examples-formik/src/main.tsx
@@ -1,13 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { config as niceFormConfig } from '@ebay/nice-form-react';
-import formikAdapter from '@ebay/nice-form-react/adapters/formikAdapter';
-import formikMuiAdapter from '@ebay/nice-form-react/adapters/formikMuiAdapter';
 import App from './App.tsx';
 import './index.css';
-
-niceFormConfig.addAdapter(formikAdapter);
-niceFormConfig.addAdapter(formikMuiAdapter);
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>


### PR DESCRIPTION
Closes #4.
Also makes all the examples lazy loaded. This should speed up first load speed of the examples website but should be tested whether this works properly in a production build too. Locally for me with a production build served with [http-server](https://www.npmjs.com/package/http-server) it did work.