### PR TITLE
Made the examples lazy loaded

### DIFF
--- a/packages/examples-antd/src/App.tsx
+++ b/packages/examples-antd/src/App.tsx
@@ -1,107 +1,95 @@
-import React, { useState } from 'react';
-import useHash from './useHash';
+import React, { Suspense, lazy } from 'react';
 import './App.css';
-import NiceFormMeta from '@ebay/nice-form-react/src/NiceFormMeta';
 import CodeViewer from './CodeViewer';
-import Basic from './examples/Basic';
-import Simple from './examples/Simple';
-import ViewEdit from './examples/ViewEdit';
-import ComplexLayout from './examples/ComplexLayout';
-import DynamicFields from './examples/DynamicFields';
-import FieldCondition from './examples/FieldCondition';
-import ViewMode from './examples/ViewMode';
-import AsyncDataSource from './examples/AsyncDataSource';
-import MultipleColumns from './examples/MultipleColumns';
-import MultipleSections from './examples/MultipleSections';
-import SingleField from './examples/SingleField';
-import Validation from './examples/Validation';
-import FormInModal from './examples/FormInModal';
-import Coordinated from './examples/Coordinated';
-import CustomComponent from './examples/CustomComponent';
-import Mixed from './examples/Mixed';
-import Wizard from './examples/Wizard';
-import FormList from './examples/FormList';
-import FormListManual from './examples/FormListManual';
+import useHash from './useHash';
+
+const lazyComponent = (importFunction: () => Promise<{ default: React.ComponentType }>) => { 
+  return lazy(importFunction);
+};
 
 const examples: {
   [key: string]: {
     name: string;
-    component: () => JSX.Element;
+    component: React.LazyExoticComponent<React.ComponentType>;
     description: React.ReactNode;
   };
 } = {
   simple: {
     name: 'Simple',
-    component: Simple,
+    component: lazyComponent(() => import('./examples/Simple')),
     description: 'The most simple usage.',
   },
-  basic: { name: 'Basic', component: Basic, description: 'Basic usage.' },
+  basic: {
+    name: 'Basic',
+    component: lazyComponent(() => import('./examples/Basic')),
+    description: 'Basic usage.'
+  },
   'view-mode': {
     name: 'View Mode',
-    component: ViewMode,
+    component: lazyComponent(() => import('./examples/ViewMode')),
     description:
       'FormBuilder could also be used as view mode just for displaying information in form layout. It could be used even without Form.',
   },
   'view-edit': {
     name: 'View / Edit',
-    component: ViewEdit,
+    component: lazyComponent(() => import('./examples/ViewEdit')),
     description: 'FormBuilder makes it super easy to toggle view/edit mode of a form.',
   },
   'dynamic-fields': {
     name: 'Dynamic Fields',
-    component: DynamicFields,
+    component: lazyComponent(() => import('./examples/DynamicFields')),
     description:
       "You can dynamically add or remove fields according to the user's input. In this example, if choose other, then a new input appears.",
   },
   'field-condition': {
     name: 'Field Condition',
-    component: FieldCondition,
+    component: lazyComponent(() => import('./examples/FieldCondition')),
     description:
       'By condition property, you can control whether to render a field or not. In this example, if choose other, then a new input appears.',
   },
   'form-list': {
     name: 'Form List',
-    component: FormList,
+    component: lazyComponent(() => import('./examples/FormList')),
     description: 'Antd form list support.',
   },
   'form-list-manual': {
     name: 'Manual Form List',
-    component: FormListManual,
+    component: lazyComponent(() => import('./examples/FormListManual')),
     description: 'Antd form list support.',
   },
 
   'async-data-source': {
     name: 'Async Data Source',
-    component: AsyncDataSource,
+    component: lazyComponent(() => import('./examples/AsyncDataSource')),
     description:
       'Some form field widgets may need to load data source if necessary, the sample shows how to do it',
   },
   'multiple-columns': {
     name: 'Multiple Columns',
-    component: MultipleColumns,
+    component: lazyComponent(() => import('./examples/MultipleColumns')),
     description:
       "It's easy to set multiple columns layout for the form. Note it should be able to divide 24",
   },
   'complex-layout': {
     name: 'Complex Layout',
-    component: ComplexLayout,
+    component: lazyComponent(() => import('./examples/ComplexLayout')),
     description: 'The example shows a complex layout. Similar approach with multiple columns.',
   },
   'multiple-sections': {
     name: 'Multiple Sections',
-    component: MultipleSections,
+    component: lazyComponent(() => import('./examples/MultipleSections')),
     description:
       'Some times you need to group fields into different fieldset, or need more complex layout. You can use multiple form metas in one form.',
   },
   'single-field': {
     name: 'Single Field',
-    component: SingleField,
+    component: lazyComponent(() => import('./examples/SingleField')),
     description:
       'You can use FormBuilder for even a single form field. This example also shows inline layout of the form.',
   },
   validation: {
     name: 'Validation',
-    component: Validation,
+    component: lazyComponent(() => import('./examples/Validation')),
     description: (
       <span>
         You can use rules property to specify how to validate fields. For more information please go
@@ -118,31 +106,31 @@ const examples: {
   },
   'form-in-modal': {
     name: 'Form in Modal',
-    component: FormInModal,
+    component: lazyComponent(() => import('./examples/FormInModal')),
     description:
       'The example shows how to use form in a dialog to call api and show status in dialog buttons.',
   },
   coordinated: {
     name: 'Coordinated Controls',
-    component: Coordinated,
+    component: lazyComponent(() => import('./examples/Coordinated')),
     description:
       'You can set field value according to input of another control by use form.setFieldsValue api.',
   },
   'custom-component': {
     name: 'Custom Component',
-    component: CustomComponent,
+    component: lazyComponent(() => import('./examples/CustomComponent')),
     description:
       "It's easy to create your own form field component, ether to get new capabilities or even just for layout.",
   },
   mixed: {
     name: 'Mixed',
-    component: Mixed,
+    component: lazyComponent(() => import('./examples/Mixed')),
     description:
       'Form builder is designed to not limit original antd form api, so you can use them together.',
   },
   wizard: {
     name: 'Wizard',
-    component: Wizard,
+    component: lazyComponent(() => import('./examples/Wizard')),
     description:
       'Wizard is an advanced usage of form builder, you can design your own meta structure to support dynamic wizard.',
   },
@@ -213,10 +201,12 @@ function App() {
         </div>
       </div>
       <div className="example-container">
-        <div>{renderExample()}</div>
-        <div className="code-container">
-          <CodeViewer code={current} />
-        </div>
+        <Suspense>
+          <div>{renderExample()}</div>
+          <div className="code-container">
+            <CodeViewer code={current} />
+          </div>
+        </Suspense>
       </div>
     </div>
   );

--- a/packages/examples-formik/src/App.tsx
+++ b/packages/examples-formik/src/App.tsx
@@ -1,89 +1,79 @@
-import React from 'react';
-import useHash from './useHash';
+import React, { Suspense, lazy } from 'react';
 import './App.css';
-// import NiceFormMeta from '@ebay/nice-form-react/src/NiceFormMeta';
 import CodeViewer from './CodeViewer';
-import Basic from './examples/Basic';
-import Simple from './examples/Simple';
-import ViewEdit from './examples/ViewEdit';
-import ComplexLayout from './examples/ComplexLayout';
-import DynamicFields from './examples/DynamicFields';
-import FieldCondition from './examples/FieldCondition';
-import ViewMode from './examples/ViewMode';
-import AsyncDataSource from './examples/AsyncDataSource';
-import MultipleColumns from './examples/MultipleColumns';
-import MultipleSections from './examples/MultipleSections';
-import Validation from './examples/Validation';
-import FormInModal from './examples/FormInModal';
-import Coordinated from './examples/Coordinated';
-import CustomComponent from './examples/CustomComponent';
-import FormList from './examples/FormList';
-import Mixed from './examples/Mixed';
-import Wizard from './examples/Wizard';
+import useHash from './useHash';
+
+const lazyComponent = (importFunction: () => Promise<{ default: React.ComponentType }>) => { 
+  return lazy(importFunction);
+};
 
 const examples: {
   [key: string]: {
     name: string;
-    component?: () => JSX.Element;
+    component?: React.LazyExoticComponent<React.ComponentType>;
     description: React.ReactNode;
   };
 } = {
   simple: {
     name: 'Simple',
-    component: Simple,
+    component: lazyComponent(() => import('./examples/Simple')),
     description: 'The most simple usage.',
   },
-  basic: { name: 'Basic', component: Basic, description: 'Basic usage.' },
+  basic: {
+    name: 'Basic',
+    component: lazyComponent(() => import('./examples/Basic')),
+    description: 'Basic usage.'
+  },
   'view-mode': {
     name: 'View Mode',
-    component: ViewMode,
+    component: lazyComponent(() => import('./examples/ViewMode')),
     description:
       'FormBuilder could also be used as view mode just for displaying information in form layout. It could be used even without Form.',
   },
   'view-edit': {
     name: 'View / Edit',
-    component: ViewEdit,
+    component: lazyComponent(() => import('./examples/ViewEdit')),
     description: 'FormBuilder makes it super easy to toggle view/edit mode of a form.',
   },
   'dynamic-fields': {
     name: 'Dynamic Fields',
-    component: DynamicFields,
+    component: lazyComponent(() => import('./examples/DynamicFields')),
     description:
       "You can dynamically add or remove fields according to the user's input. In this example, if choose other, then a new input appears.",
   },
   'field-condition': {
     name: 'Field Condition',
-    component: FieldCondition,
+    component: lazyComponent(() => import('./examples/FieldCondition')),
     description:
       'By condition property, you can control whether to render a field or not. In this example, if choose other, then a new input appears.',
   },
   'form-list': {
     name: 'Form List',
-    component: FormList,
+    component: lazyComponent(() => import('./examples/FormList')),
     description:
       'Form list is a common usage of form builder, it allows you to add/remove form fields dynamically.',
   },
 
   'async-data-source': {
     name: 'Async Data Source',
-    component: AsyncDataSource,
+    component: lazyComponent(() => import('./examples/AsyncDataSource')),
     description:
       'Some form field widgets may need to load data source if necessary, the sample shows how to do it',
   },
   'multiple-columns': {
     name: 'Multiple Columns',
-    component: MultipleColumns,
+    component: lazyComponent(() => import('./examples/MultipleColumns')),
     description:
       "It's easy to set multiple columns layout for the form. Note it should be able to divide 24",
   },
   'complex-layout': {
     name: 'Complex Layout',
-    component: ComplexLayout,
+    component: lazyComponent(() => import('./examples/ComplexLayout')),
     description: 'The example shows a complex layout. Similar approach with multiple columns.',
   },
   'multiple-sections': {
     name: 'Multiple Sections',
-    component: MultipleSections,
+    component: lazyComponent(() => import('./examples/MultipleSections')),
     description:
       'Some times you need to group fields into different fieldset, or need more complex layout. You can use multiple form builders in one form.',
   },
@@ -95,7 +85,7 @@ const examples: {
   // },
   validation: {
     name: 'Validation',
-    component: Validation,
+    component: lazyComponent(() => import('./examples/Validation')),
     description: (
       <span>
         You can use rules property to specify how to validate fields. For more information please go
@@ -112,31 +102,31 @@ const examples: {
   },
   'form-in-modal': {
     name: 'Form in Modal',
-    component: FormInModal,
+    component: lazyComponent(() => import('./examples/FormInModal')),
     description:
       'The example shows how to use form in a dialog to call api and show status in dialog buttons.',
   },
   coordinated: {
     name: 'Coordinated Controls',
-    component: Coordinated,
+    component: lazyComponent(() => import('./examples/Coordinated')),
     description:
       'You can set field value according to input of another control by use form.setFieldsValue api.',
   },
   'custom-component': {
     name: 'Custom Component',
-    component: CustomComponent,
+    component: lazyComponent(() => import('./examples/CustomComponent')),
     description:
       "It's easy to create your own form field component, ether to get new capabilities or even just for layout.",
   },
   mixed: {
     name: 'Mixed',
-    component: Mixed,
+    component: lazyComponent(() => import('./examples/Mixed')),
     description:
       'Form builder is designed to not limit original antd form api, so you can use them together.',
   },
   wizard: {
     name: 'Wizard',
-    component: Wizard,
+    component: lazyComponent(() => import('./examples/Wizard')),
     description:
       'Wizard is an advanced usage of form builder, you can design your own meta structure to support dynamic wizard.',
   },
@@ -207,10 +197,12 @@ function App() {
         </div>
       </div>
       <div className="example-container">
-        <div>{renderExample()}</div>
-        <div className="code-container">
-          <CodeViewer code={current} />
-        </div>
+        <Suspense>
+          <div>{renderExample()}</div>
+          <div className="code-container">
+            <CodeViewer code={current} />
+          </div>
+        </Suspense>
       </div>
     </div>
   );

--- a/packages/examples-formik/src/examples/Mixed.tsx
+++ b/packages/examples-formik/src/examples/Mixed.tsx
@@ -1,31 +1,9 @@
-import { Form, Formik } from 'formik';
 import NiceForm from '@ebay/nice-form-react';
 import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import { fieldToDatePicker } from 'formik-mui-x-date-pickers';
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import type { Dayjs } from 'dayjs';
-
-const MyDatePicker = ({ ...props }) => {
-  props.onChange = (value: Dayjs | null) => {
-    props.form.setFieldTouched(props.field.name, true, false);
-    props.form.setFieldValue(props.field.name, value, true);
-    props.field.onChange(value);
-  };
-  props.onBlur = () => {
-    props.form.setFieldTouched(props.field.name, true, true);
-    props.field.onBlur();
-  };
-  return (
-    <DatePicker {...fieldToDatePicker({ field: props.field, form: props.form, meta: props.meta })}>
-      {props.children}
-    </DatePicker>
-  );
-};
-
-NiceForm.defineWidget('date-picker', MyDatePicker, ({ field }) => field);
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { Form, Formik } from 'formik';
 
 const Mixed = () => {
   const getMeta1 = () => {

--- a/packages/examples-formik/src/main.tsx
+++ b/packages/examples-formik/src/main.tsx
@@ -1,10 +1,32 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import { config as niceFormConfig } from '@ebay/nice-form-react';
+import NiceForm, { config as niceFormConfig } from '@ebay/nice-form-react';
 import formikAdapter from '@ebay/nice-form-react/adapters/formikAdapter';
 import formikMuiAdapter from '@ebay/nice-form-react/adapters/formikMuiAdapter';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import type { Dayjs } from 'dayjs';
+import { fieldToDatePicker } from 'formik-mui-x-date-pickers';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+
+const MyDatePicker = ({ ...props }) => {
+  props.onChange = (value: Dayjs | null) => {
+    props.form.setFieldTouched(props.field.name, true, false);
+    props.form.setFieldValue(props.field.name, value, true);
+    props.field.onChange(value);
+  };
+  props.onBlur = () => {
+    props.form.setFieldTouched(props.field.name, true, true);
+    props.field.onBlur();
+  };
+  return (
+    <DatePicker {...fieldToDatePicker({ field: props.field, form: props.form, meta: props.meta })}>
+      {props.children}
+    </DatePicker>
+  );
+};
+
+NiceForm.defineWidget('date-picker', MyDatePicker, ({ field }) => field);
 
 niceFormConfig.addAdapter(formikAdapter);
 niceFormConfig.addAdapter(formikMuiAdapter);


### PR DESCRIPTION
As discussed [here](https://github.com/eBay/nice-form-react/pull/5#issuecomment-2016649522), this PR makes the examples lazy loaded so the first load is faster as it just has to load in the code and corresponding imports of 1 example instead of all of them.

To test this, it is important to make a production build and hard refresh on every example page separately, as that will make it start with a clean slate. That way, you know for sure that code from one example isn't depended on from another example, as this will now break. 